### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ghactions-autoupdate.yml
+++ b/.github/workflows/ghactions-autoupdate.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.4.0
+      uses: actions/checkout@v3.5.0
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
 

--- a/.github/workflows/python-inotify-watcher.yml
+++ b/.github/workflows/python-inotify-watcher.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.4.0
+      uses: actions/checkout@v3.5.0
 
     - name: Set up Python
       uses: actions/setup-python@v4.5.0
@@ -46,7 +46,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.4.0
+      uses: actions/checkout@v3.5.0
 
     - name: Set up Python
       uses: actions/setup-python@v4.5.0


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.0](https://github.com/actions/checkout/releases/tag/v3.5.0)** on 2023-03-24T05:41:31Z
