### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ghactions-autoupdate.yml
+++ b/.github/workflows/ghactions-autoupdate.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v3.5.2
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
 

--- a/.github/workflows/python-inotify-watcher.yml
+++ b/.github/workflows/python-inotify-watcher.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v3.5.2
 
     - name: Set up Python
-      uses: actions/setup-python@v4.5.0
+      uses: actions/setup-python@v4.6.0
       with:
         python-version: 3.8
 
@@ -46,10 +46,10 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v3.5.2
 
     - name: Set up Python
-      uses: actions/setup-python@v4.5.0
+      uses: actions/setup-python@v4.6.0
       with:
         python-version: 3.8
 
@@ -61,7 +61,7 @@ jobs:
       run: pytest --cov inotify_watcher --cov-report xml tests
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3.1.1
+      uses: codecov/codecov-action@v3.1.3
       with:
         files: coverage.xml
         fail_ci_if_error: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v3.1.2](https://github.com/codecov/codecov-action/releases/tag/v3.1.2)** on 2023-04-11T20:10:46Z
