### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/python-inotify-watcher.yml
+++ b/.github/workflows/python-inotify-watcher.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v3.5.3
 
     - name: Set up Python
-      uses: actions/setup-python@v4.6.1
+      uses: actions/setup-python@v4.7.0
       with:
         python-version: 3.8
 
@@ -29,14 +29,14 @@ jobs:
 
     - name: Publish package to TestPyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@v1.8.7
+      uses: pypa/gh-action-pypi-publish@v1.8.8
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish package to PyPI
       if: startsWith(github.ref, 'refs/tags') && !contains(github.ref, 'dev')
-      uses: pypa/gh-action-pypi-publish@v1.8.7
+      uses: pypa/gh-action-pypi-publish@v1.8.8
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
 
@@ -49,7 +49,7 @@ jobs:
       uses: actions/checkout@v3.5.3
 
     - name: Set up Python
-      uses: actions/setup-python@v4.6.1
+      uses: actions/setup-python@v4.7.0
       with:
         python-version: 3.8
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** published a new release **[v1.8.8](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.8.8)** on 2023-07-12T01:05:05Z
